### PR TITLE
Do not fill if slot is not empty.

### DIFF
--- a/core/src/main/java/dev/triumphteam/gui/components/util/GuiFiller.java
+++ b/core/src/main/java/dev/triumphteam/gui/components/util/GuiFiller.java
@@ -92,8 +92,8 @@ public final class GuiFiller {
                     || i == 27 || i == 36
                     || i == 17 || i == 26
                     || i == 35 || i == 44)
-                gui.setItem(i, items.get(i));
-
+                if (gui.getItem(i) == null)
+                    gui.setItem(i, items.get(i));
         }
     }
 


### PR DESCRIPTION
GuiFiller is bugged if you try to fill the border of a GUI because it replaces all existing slots without checking for existing items.

This pr can fix this bug.

#17 